### PR TITLE
Fix content generation project retrieval

### DIFF
--- a/src/app/(dashboard)/project/[id]/idea/[idea_id]/page.tsx
+++ b/src/app/(dashboard)/project/[id]/idea/[idea_id]/page.tsx
@@ -92,6 +92,7 @@ export default function IdeaContentPage() {
         },
         body: JSON.stringify({
           idea_text: idea.idea_text,
+          project_id: params?.id,
           regenerate: !!generatedContent,
           platform: project?.platform || 'twitter',
         }),

--- a/src/app/api/content/generate/route.ts
+++ b/src/app/api/content/generate/route.ts
@@ -23,14 +23,19 @@ export async function POST(request: Request) {
     }
 
     // 2. Parse request body
-    const { idea_text } = await request.json();
+    const { idea_text, project_id } = await request.json();
 
-    // 3. Get project tone if available
-    const { data: project } = await supabase
+    // 3. Get project info using provided project_id
+    const { data: project, error: projectError } = await supabase
       .from('projects')
       .select('*')
+      .eq('id', project_id)
       .eq('user_id', user.id)
       .single();
+
+    if (projectError || !project) {
+      return NextResponse.json({ error: 'Project not found' }, { status: 404 });
+    }
 
     const content = await generateDraftFromIdea(idea_text, project);
 


### PR DESCRIPTION
## Summary
- include project ID when requesting AI content generation
- fetch project by ID in the generation API route to avoid null project errors

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6844786880608327a94fda001ffc698b