### PR TITLE
Archive ideas instead of deleting

### DIFF
--- a/src/api/ideas.ts
+++ b/src/api/ideas.ts
@@ -15,7 +15,7 @@ export async function getIdeasForProject(project_id: string, user_id: string): P
 export async function deleteIdea(idea_id: string, user_id: string): Promise<void> {
   await supabase
     .from("ideas")
-    .delete()
+    .update({ status: 'archived' })
     .eq("id", idea_id)
     .eq("user_id", user_id)
 }

--- a/src/components/projects/GeneratedIdeasList.tsx
+++ b/src/components/projects/GeneratedIdeasList.tsx
@@ -68,8 +68,8 @@ export function GeneratedIdeasList({ ideas, onDelete, projectId, onFilterClick }
                   onDelete(idea)
                 }}
                 className="p-1 text-base-content/50 hover:text-error"
-                title="Delete idea"
-                aria-label="Delete idea"
+                title="Archive idea"
+                aria-label="Archive idea"
               >
                 <span className="icon-[tabler--x] size-4" />
               </button>

--- a/src/hooks/useIdeas.ts
+++ b/src/hooks/useIdeas.ts
@@ -70,7 +70,11 @@ export function useIdeas({ projectId, userId, accessToken, enabled = true }: Use
     setDeleteError(null)
     try {
       await IdeasService.delete({ ideaId, userId })
-      setIdeas((prev) => prev.filter((i) => i.id !== ideaId))
+      setIdeas((prev) =>
+        prev.map((i) =>
+          i.id === ideaId ? { ...i, status: "archived" } : i
+        )
+      )
     } catch (err) {
       setDeleteError(err instanceof Error ? err.message : "Failed to delete idea")
     }

--- a/src/services/ideas.ts
+++ b/src/services/ideas.ts
@@ -43,7 +43,7 @@ export class IdeasService {
     const supabase = getSupabaseClient()
     const { error } = await supabase
       .from("ideas")
-      .delete()
+      .update({ status: "archived" })
       .eq("id", ideaId)
       .eq("user_id", userId)
 


### PR DESCRIPTION
## Summary
- update idea removal to set status `archived` instead of deleting
- adjust list button label to `Archive idea`

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font)*

------
https://chatgpt.com/codex/tasks/task_e_6849ee4d25548327b7c08c80c698aae2