### PR TITLE
Add content rewrite helper

### DIFF
--- a/src/app/(dashboard)/project/[id]/idea/[idea_id]/page.tsx
+++ b/src/app/(dashboard)/project/[id]/idea/[idea_id]/page.tsx
@@ -22,6 +22,8 @@ export default function IdeaContentPage() {
   const [editedText, setEditedText] = useState('');
   const [isUpdating, setIsUpdating] = useState(false);
   const [statusUpdating, setStatusUpdating] = useState(false);
+  const [rewriteMenuOpen, setRewriteMenuOpen] = useState(false);
+  const [isRewriting, setIsRewriting] = useState(false);
 
   useEffect(() => {
     const fetchIdea = async () => {
@@ -149,6 +151,43 @@ export default function IdeaContentPage() {
       toast.error('Failed to save content. Please try again.');
     } finally {
       setIsSaving(false);
+    }
+  };
+
+  const handleShorten = async () => {
+    if (!generatedContent) return;
+    setIsRewriting(true);
+    try {
+      const { data: { session }, error: sessionError } = await supabase.auth.getSession();
+      const accessToken = session?.access_token;
+      if (sessionError || !accessToken) {
+        toast.error('You must be signed in to rewrite content.');
+        return;
+      }
+
+      const response = await fetch('/api/content/rewrite', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({ text: generatedContent, action: 'shorten' }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || 'Failed to rewrite content');
+      }
+
+      const data = await response.json();
+      setGeneratedContent(data.text);
+      toast.success('✅ Content shortened!');
+    } catch (error) {
+      console.error('Error rewriting content:', error);
+      toast.error('Failed to rewrite content.');
+    } finally {
+      setIsRewriting(false);
+      setRewriteMenuOpen(false);
     }
   };
 
@@ -358,12 +397,30 @@ export default function IdeaContentPage() {
           </div>
           <div className="card bg-base-100 border border-base-200 rounded-xl shadow-sm mb-4">
             <div className="card-body p-6">
-              <textarea
-                value={generatedContent}
-                onChange={(e) => setGeneratedContent(e.target.value)}
-                className="textarea textarea-bordered w-full min-h-[250px]"
-                placeholder="Edit your content here..."
-              />
+                <textarea
+                  value={generatedContent}
+                  onChange={(e) => setGeneratedContent(e.target.value)}
+                  className="textarea textarea-bordered w-full min-h-[250px]"
+                  placeholder="Edit your content here..."
+                />
+                <div className="relative inline-block mt-2" tabIndex={0} onBlur={() => setRewriteMenuOpen(false)}>
+                  <button
+                    onClick={() => setRewriteMenuOpen((v) => !v)}
+                    className="btn btn-ghost btn-sm"
+                    aria-label="Rewrite options"
+                  >
+                    <span className="icon-[tabler--wand] size-4" />
+                  </button>
+                  {rewriteMenuOpen && (
+                    <ul className="absolute z-10 mt-1 menu p-2 bg-base-100 rounded-box shadow-md w-32 text-sm">
+                      <li>
+                        <button onClick={handleShorten} disabled={isRewriting}>
+                          {isRewriting ? 'Shortening...' : 'Shorten'}
+                        </button>
+                      </li>
+                    </ul>
+                  )}
+                </div>
             </div>
           </div>
         </div>

--- a/src/app/api/content/rewrite/route.ts
+++ b/src/app/api/content/rewrite/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import { createSupabaseServerClient } from '@/lib/supabaseServerClient';
+import { rewriteContent } from '@/lib/ai/rewriteContent';
+
+function getAccessToken(request: Request): string | null {
+  const authHeader = request.headers.get('authorization');
+  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
+  return authHeader.replace('Bearer ', '');
+}
+
+export async function POST(request: Request) {
+  try {
+    const accessToken = getAccessToken(request);
+    if (!accessToken) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    const supabase = createSupabaseServerClient(accessToken);
+    const { data: { user }, error: userError } = await supabase.auth.getUser();
+    if (userError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { text, action } = await request.json();
+    if (typeof text !== 'string' || action !== 'shorten') {
+      return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
+    }
+
+    const rewritten = await rewriteContent(text, 'shorten');
+    return NextResponse.json({ text: rewritten });
+  } catch (error) {
+    console.error('Rewrite error:', error);
+    return NextResponse.json({ error: 'Failed to rewrite content' }, { status: 500 });
+  }
+}

--- a/src/lib/ai/rewriteContent.ts
+++ b/src/lib/ai/rewriteContent.ts
@@ -1,0 +1,22 @@
+import OpenAI from "openai";
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+export async function rewriteContent(text: string, action: "shorten") {
+  let prompt: string;
+  switch (action) {
+    case "shorten":
+      prompt = `Shorten the following text while keeping its original meaning:\n\n${text}`;
+      break;
+    default:
+      throw new Error("Unsupported action");
+  }
+
+  const response = await openai.responses.create({
+    model: "gpt-4.1-mini",
+    instructions: "You rewrite content based on a provided action.",
+    input: prompt,
+  });
+
+  return response.output_text.trim();
+}


### PR DESCRIPTION
## Summary
- implement content rewrite API using OpenAI gpt-4.1-mini
- expose `/api/content/rewrite` endpoint
- add rewrite helper UI on idea detail page
- fix route action type check
- move rewrite helper button below the text area

## Testing
- `npm run lint`
- `npm run build` *(fails to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6856da65be08832787c968918e58caf3