### PR TITLE
Add tone rewrite options

### DIFF
--- a/src/app/(dashboard)/project/[id]/idea/[idea_id]/page.tsx
+++ b/src/app/(dashboard)/project/[id]/idea/[idea_id]/page.tsx
@@ -23,8 +23,19 @@ export default function IdeaContentPage() {
   const [isUpdating, setIsUpdating] = useState(false);
   const [statusUpdating, setStatusUpdating] = useState(false);
   const [rewriteMenuOpen, setRewriteMenuOpen] = useState(false);
+  const [toneMenuOpen, setToneMenuOpen] = useState(false);
   const [isRewriting, setIsRewriting] = useState(false);
-  const [rewriteAction, setRewriteAction] = useState<"shorten" | "expand" | "fix" | null>(null);
+  const [rewriteAction, setRewriteAction] = useState<
+    | "shorten"
+    | "expand"
+    | "fix"
+    | "tone_professional"
+    | "tone_empathetic"
+    | "tone_casual"
+    | "tone_neutral"
+    | "tone_educational"
+    | null
+  >(null);
 
   useEffect(() => {
     const fetchIdea = async () => {
@@ -278,6 +289,51 @@ export default function IdeaContentPage() {
     }
   };
 
+  const handleTone = async (
+    tone: 'professional' | 'empathetic' | 'casual' | 'neutral' | 'educational',
+  ) => {
+    if (!generatedContent) return;
+    setRewriteAction(`tone_${tone}` as const);
+    setIsRewriting(true);
+    try {
+      const {
+        data: { session },
+        error: sessionError,
+      } = await supabase.auth.getSession();
+      const accessToken = session?.access_token;
+      if (sessionError || !accessToken) {
+        toast.error('You must be signed in to rewrite content.');
+        return;
+      }
+
+      const response = await fetch('/api/content/rewrite', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({ text: generatedContent, action: tone }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || 'Failed to rewrite content');
+      }
+
+      const data = await response.json();
+      setGeneratedContent(data.text);
+      toast.success(`✅ Tone updated to ${tone.charAt(0).toUpperCase() + tone.slice(1)}!`);
+    } catch (error) {
+      console.error('Error rewriting content:', error);
+      toast.error('Failed to rewrite content.');
+    } finally {
+      setIsRewriting(false);
+      setRewriteAction(null);
+      setRewriteMenuOpen(false);
+      setToneMenuOpen(false);
+    }
+  };
+
   const handleUpdateIdea = async () => {
     if (!idea || !editedText) return;
     setIsUpdating(true);
@@ -514,6 +570,45 @@ export default function IdeaContentPage() {
                         <button onClick={handleFix} disabled={isRewriting}>
                           {isRewriting && rewriteAction === 'fix' ? 'Fixing...' : 'Fix Grammar'}
                         </button>
+                      </li>
+                      <li className="relative" tabIndex={0} onBlur={() => setToneMenuOpen(false)}>
+                        <button
+                          onClick={() => setToneMenuOpen(v => !v)}
+                          className="flex items-center justify-between w-full"
+                          disabled={isRewriting}
+                        >
+                          Change tone to...
+                          <span className="icon-[tabler--chevron-right] size-4" />
+                        </button>
+                        {toneMenuOpen && (
+                          <ul className="absolute left-full top-0 ml-2 menu p-2 bg-base-100 rounded-box shadow-md w-40 text-sm">
+                            <li>
+                              <button onClick={() => handleTone('professional')} disabled={isRewriting}>
+                                {isRewriting && rewriteAction === 'tone_professional' ? 'Changing...' : 'Professional'}
+                              </button>
+                            </li>
+                            <li>
+                              <button onClick={() => handleTone('empathetic')} disabled={isRewriting}>
+                                {isRewriting && rewriteAction === 'tone_empathetic' ? 'Changing...' : 'Empathetic'}
+                              </button>
+                            </li>
+                            <li>
+                              <button onClick={() => handleTone('casual')} disabled={isRewriting}>
+                                {isRewriting && rewriteAction === 'tone_casual' ? 'Changing...' : 'Casual'}
+                              </button>
+                            </li>
+                            <li>
+                              <button onClick={() => handleTone('neutral')} disabled={isRewriting}>
+                                {isRewriting && rewriteAction === 'tone_neutral' ? 'Changing...' : 'Neutral'}
+                              </button>
+                            </li>
+                            <li>
+                              <button onClick={() => handleTone('educational')} disabled={isRewriting}>
+                                {isRewriting && rewriteAction === 'tone_educational' ? 'Changing...' : 'Educational'}
+                              </button>
+                            </li>
+                          </ul>
+                        )}
                       </li>
                     </ul>
                   )}

--- a/src/app/api/content/rewrite/route.ts
+++ b/src/app/api/content/rewrite/route.ts
@@ -23,7 +23,16 @@ export async function POST(request: Request) {
     const { text, action } = await request.json();
     if (
       typeof text !== 'string' ||
-      (action !== 'shorten' && action !== 'expand' && action !== 'fix')
+      ![
+        'shorten',
+        'expand',
+        'fix',
+        'professional',
+        'empathetic',
+        'casual',
+        'neutral',
+        'educational',
+      ].includes(action)
     ) {
       return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
     }

--- a/src/lib/ai/rewriteContent.ts
+++ b/src/lib/ai/rewriteContent.ts
@@ -2,7 +2,18 @@ import OpenAI from "openai";
 
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
-export async function rewriteContent(text: string, action: "shorten" | "expand" | "fix") {
+export async function rewriteContent(
+  text: string,
+  action:
+    | "shorten"
+    | "expand"
+    | "fix"
+    | "professional"
+    | "empathetic"
+    | "casual"
+    | "neutral"
+    | "educational",
+) {
   let prompt: string;
   switch (action) {
     case "shorten":
@@ -13,6 +24,21 @@ export async function rewriteContent(text: string, action: "shorten" | "expand" 
       break;
     case "fix":
       prompt = `Fix any grammar or spelling mistakes in the following text without changing its meaning:\n\n${text}`;
+      break;
+    case "professional":
+      prompt = `Rewrite the following text in a professional tone:\n\n${text}`;
+      break;
+    case "empathetic":
+      prompt = `Rewrite the following text in an empathetic tone:\n\n${text}`;
+      break;
+    case "casual":
+      prompt = `Rewrite the following text in a casual tone:\n\n${text}`;
+      break;
+    case "neutral":
+      prompt = `Rewrite the following text in a neutral tone:\n\n${text}`;
+      break;
+    case "educational":
+      prompt = `Rewrite the following text in an educational tone:\n\n${text}`;
       break;
     default:
       throw new Error("Unsupported action");


### PR DESCRIPTION
## Summary
- expand rewrite helper to support tone options
- validate tone actions in rewrite API
- add dropdown for changing tone on idea page

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856e8d7011c8327bcc02c220b40b64a