### PR TITLE
Add tone rewrite options

### DIFF
--- a/src/app/api/content/rewrite/route.ts
+++ b/src/app/api/content/rewrite/route.ts
@@ -23,7 +23,16 @@ export async function POST(request: Request) {
     const { text, action } = await request.json();
     if (
       typeof text !== 'string' ||
-      (action !== 'shorten' && action !== 'expand' && action !== 'fix')
+      ![
+        'shorten',
+        'expand',
+        'fix',
+        'professional',
+        'empathetic',
+        'casual',
+        'neutral',
+        'educational',
+      ].includes(action)
     ) {
       return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
     }

--- a/src/lib/ai/rewriteContent.ts
+++ b/src/lib/ai/rewriteContent.ts
@@ -2,7 +2,18 @@ import OpenAI from "openai";
 
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
-export async function rewriteContent(text: string, action: "shorten" | "expand" | "fix") {
+export async function rewriteContent(
+  text: string,
+  action:
+    | "shorten"
+    | "expand"
+    | "fix"
+    | "professional"
+    | "empathetic"
+    | "casual"
+    | "neutral"
+    | "educational",
+) {
   let prompt: string;
   switch (action) {
     case "shorten":
@@ -13,6 +24,21 @@ export async function rewriteContent(text: string, action: "shorten" | "expand" 
       break;
     case "fix":
       prompt = `Fix any grammar or spelling mistakes in the following text without changing its meaning:\n\n${text}`;
+      break;
+    case "professional":
+      prompt = `Rewrite the following text in a professional tone:\n\n${text}`;
+      break;
+    case "empathetic":
+      prompt = `Rewrite the following text in an empathetic tone:\n\n${text}`;
+      break;
+    case "casual":
+      prompt = `Rewrite the following text in a casual tone:\n\n${text}`;
+      break;
+    case "neutral":
+      prompt = `Rewrite the following text in a neutral tone:\n\n${text}`;
+      break;
+    case "educational":
+      prompt = `Rewrite the following text in an educational tone:\n\n${text}`;
       break;
     default:
       throw new Error("Unsupported action");


### PR DESCRIPTION
## Summary
- expand rewrite helper to support tone options
- validate tone actions in rewrite API
- add dropdown for changing tone on idea page
- fix dropdown closing when selecting tone

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856e8d7011c8327bcc02c220b40b64a