### PR TITLE
Add custom rewrite prompt

### DIFF
--- a/src/app/api/content/rewrite/route.ts
+++ b/src/app/api/content/rewrite/route.ts
@@ -20,13 +20,14 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const { text, action } = await request.json();
+    const { text, action, prompt } = await request.json();
     if (
       typeof text !== 'string' ||
       ![
         'shorten',
         'expand',
         'fix',
+        'custom',
         'professional',
         'empathetic',
         'casual',
@@ -37,7 +38,7 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
     }
 
-    const rewritten = await rewriteContent(text, action);
+    const rewritten = await rewriteContent(text, action, prompt);
     return NextResponse.json({ text: rewritten });
   } catch (error) {
     console.error('Rewrite error:', error);

--- a/src/lib/ai/rewriteContent.ts
+++ b/src/lib/ai/rewriteContent.ts
@@ -8,11 +8,13 @@ export async function rewriteContent(
     | "shorten"
     | "expand"
     | "fix"
+    | "custom"
     | "professional"
     | "empathetic"
     | "casual"
     | "neutral"
     | "educational",
+  customPrompt?: string
 ) {
   let prompt: string;
   switch (action) {
@@ -40,13 +42,17 @@ export async function rewriteContent(
     case "educational":
       prompt = `Rewrite the following text in an educational tone:\n\n${text}`;
       break;
+    case "custom":
+      if (!customPrompt) throw new Error("Custom prompt required");
+      prompt = `${customPrompt}\n\n${text}`;
+      break;
     default:
       throw new Error("Unsupported action");
   }
 
   const response = await openai.responses.create({
     model: "gpt-4.1-mini",
-    instructions: "You rewrite content based on a provided action.",
+    instructions: "You rewrite content based on a provided action or prompt.",
     input: prompt,
   });
 


### PR DESCRIPTION
## Summary
- allow custom prompt rewriting
- extend rewrite menu UI and positioning
- enlarge rewrite dropdown, open above button
- update API & server logic for custom prompt

## Testing
- `npx -y next@15.3.4 lint`

------
https://chatgpt.com/codex/tasks/task_e_685711686ab08327bc237650ac4bd6c8