### PR TITLE
Add custom rewrite prompt

### DIFF
--- a/src/app/(dashboard)/project/[id]/idea/[idea_id]/page.tsx
+++ b/src/app/(dashboard)/project/[id]/idea/[idea_id]/page.tsx
@@ -25,10 +25,12 @@ export default function IdeaContentPage() {
   const [rewriteMenuOpen, setRewriteMenuOpen] = useState(false);
   const [toneMenuOpen, setToneMenuOpen] = useState(false);
   const [isRewriting, setIsRewriting] = useState(false);
+  const [customPrompt, setCustomPrompt] = useState('');
   const [rewriteAction, setRewriteAction] = useState<
     | "shorten"
     | "expand"
     | "fix"
+    | "custom"
     | "tone_professional"
     | "tone_empathetic"
     | "tone_casual"
@@ -279,6 +281,53 @@ export default function IdeaContentPage() {
       const data = await response.json();
       setGeneratedContent(data.text);
       toast.success('✅ Grammar fixed!');
+    } catch (error) {
+      console.error('Error rewriting content:', error);
+      toast.error('Failed to rewrite content.');
+    } finally {
+      setIsRewriting(false);
+      setRewriteAction(null);
+      setRewriteMenuOpen(false);
+    }
+  };
+
+  const handleCustomRewrite = async () => {
+    if (!generatedContent || !customPrompt.trim()) return;
+    setRewriteAction('custom');
+    setIsRewriting(true);
+    try {
+      const {
+        data: { session },
+        error: sessionError,
+      } = await supabase.auth.getSession();
+      const accessToken = session?.access_token;
+      if (sessionError || !accessToken) {
+        toast.error('You must be signed in to rewrite content.');
+        return;
+      }
+
+      const response = await fetch('/api/content/rewrite', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({
+          text: generatedContent,
+          action: 'custom',
+          prompt: customPrompt.trim(),
+        }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || 'Failed to rewrite content');
+      }
+
+      const data = await response.json();
+      setGeneratedContent(data.text);
+      toast.success('✅ Content updated!');
+      setCustomPrompt('');
     } catch (error) {
       console.error('Error rewriting content:', error);
       toast.error('Failed to rewrite content.');
@@ -563,70 +612,86 @@ export default function IdeaContentPage() {
                     <span className="icon-[tabler--wand] size-4" />
                   </button>
                   {rewriteMenuOpen && (
-                    <ul className="absolute z-10 mt-1 menu p-2 bg-base-100 rounded-box shadow-md w-32 text-sm">
-                      <li>
-                        <button onClick={handleShorten} disabled={isRewriting}>
-                          {isRewriting && rewriteAction === 'shorten' ? 'Shortening...' : 'Shorten'}
-                        </button>
-                      </li>
-                      <li>
-                        <button onClick={handleExpand} disabled={isRewriting}>
-                          {isRewriting && rewriteAction === 'expand' ? 'Expanding...' : 'Expand'}
-                        </button>
-                      </li>
-                      <li>
-                        <button onClick={handleFix} disabled={isRewriting}>
-                          {isRewriting && rewriteAction === 'fix' ? 'Fixing...' : 'Fix Grammar'}
-                        </button>
-                      </li>
-                      <li
-                        className="relative"
-                        tabIndex={0}
-                        onBlur={(e) => {
-                          if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-                            setToneMenuOpen(false);
-                          }
-                        }}
+                    <div className="absolute z-10 bottom-full mb-1 w-56 bg-base-100 rounded-box shadow-md p-2 text-sm space-y-2">
+                      <input
+                        type="text"
+                        placeholder="write with ai or select from below"
+                        className="input input-bordered input-sm w-full"
+                        value={customPrompt}
+                        onChange={(e) => setCustomPrompt(e.target.value)}
+                      />
+                      <button
+                        onClick={handleCustomRewrite}
+                        className="btn btn-primary btn-sm w-full"
+                        disabled={isRewriting}
                       >
-                        <button
-                          onClick={() => setToneMenuOpen((v) => !v)}
-                          className="flex items-center justify-between w-full"
-                          disabled={isRewriting}
+                        {isRewriting && rewriteAction === 'custom' ? 'Rewriting...' : 'Rewrite'}
+                      </button>
+                      <ul className="menu p-0">
+                        <li>
+                          <button onClick={handleShorten} disabled={isRewriting}>
+                            {isRewriting && rewriteAction === 'shorten' ? 'Shortening...' : 'Shorten'}
+                          </button>
+                        </li>
+                        <li>
+                          <button onClick={handleExpand} disabled={isRewriting}>
+                            {isRewriting && rewriteAction === 'expand' ? 'Expanding...' : 'Expand'}
+                          </button>
+                        </li>
+                        <li>
+                          <button onClick={handleFix} disabled={isRewriting}>
+                            {isRewriting && rewriteAction === 'fix' ? 'Fixing...' : 'Fix Grammar'}
+                          </button>
+                        </li>
+                        <li
+                          className="relative"
+                          tabIndex={0}
+                          onBlur={(e) => {
+                            if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+                              setToneMenuOpen(false);
+                            }
+                          }}
                         >
-                          Change tone to...
-                          <span className="icon-[tabler--chevron-right] size-4" />
-                        </button>
-                        {toneMenuOpen && (
-                          <ul className="absolute left-full top-0 ml-2 menu p-2 bg-base-100 rounded-box shadow-md w-40 text-sm">
-                            <li>
-                              <button onClick={() => handleTone('professional')} disabled={isRewriting}>
-                                {isRewriting && rewriteAction === 'tone_professional' ? 'Changing...' : 'Professional'}
-                              </button>
-                            </li>
-                            <li>
-                              <button onClick={() => handleTone('empathetic')} disabled={isRewriting}>
-                                {isRewriting && rewriteAction === 'tone_empathetic' ? 'Changing...' : 'Empathetic'}
-                              </button>
-                            </li>
-                            <li>
-                              <button onClick={() => handleTone('casual')} disabled={isRewriting}>
-                                {isRewriting && rewriteAction === 'tone_casual' ? 'Changing...' : 'Casual'}
-                              </button>
-                            </li>
-                            <li>
-                              <button onClick={() => handleTone('neutral')} disabled={isRewriting}>
-                                {isRewriting && rewriteAction === 'tone_neutral' ? 'Changing...' : 'Neutral'}
-                              </button>
-                            </li>
-                            <li>
-                              <button onClick={() => handleTone('educational')} disabled={isRewriting}>
-                                {isRewriting && rewriteAction === 'tone_educational' ? 'Changing...' : 'Educational'}
-                              </button>
-                            </li>
-                          </ul>
-                        )}
-                      </li>
-                    </ul>
+                          <button
+                            onClick={() => setToneMenuOpen((v) => !v)}
+                            className="flex items-center justify-between w-full"
+                            disabled={isRewriting}
+                          >
+                            Change tone to...
+                            <span className="icon-[tabler--chevron-right] size-4" />
+                          </button>
+                          {toneMenuOpen && (
+                            <ul className="absolute left-full top-0 ml-2 menu p-2 bg-base-100 rounded-box shadow-md w-40 text-sm">
+                              <li>
+                                <button onClick={() => handleTone('professional')} disabled={isRewriting}>
+                                  {isRewriting && rewriteAction === 'tone_professional' ? 'Changing...' : 'Professional'}
+                                </button>
+                              </li>
+                              <li>
+                                <button onClick={() => handleTone('empathetic')} disabled={isRewriting}>
+                                  {isRewriting && rewriteAction === 'tone_empathetic' ? 'Changing...' : 'Empathetic'}
+                                </button>
+                              </li>
+                              <li>
+                                <button onClick={() => handleTone('casual')} disabled={isRewriting}>
+                                  {isRewriting && rewriteAction === 'tone_casual' ? 'Changing...' : 'Casual'}
+                                </button>
+                              </li>
+                              <li>
+                                <button onClick={() => handleTone('neutral')} disabled={isRewriting}>
+                                  {isRewriting && rewriteAction === 'tone_neutral' ? 'Changing...' : 'Neutral'}
+                                </button>
+                              </li>
+                              <li>
+                                <button onClick={() => handleTone('educational')} disabled={isRewriting}>
+                                  {isRewriting && rewriteAction === 'tone_educational' ? 'Changing...' : 'Educational'}
+                                </button>
+                              </li>
+                            </ul>
+                          )}
+                        </li>
+                      </ul>
+                    </div>
                   )}
                 </div>
             </div>

--- a/src/app/api/content/rewrite/route.ts
+++ b/src/app/api/content/rewrite/route.ts
@@ -20,13 +20,14 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const { text, action } = await request.json();
+    const { text, action, prompt } = await request.json();
     if (
       typeof text !== 'string' ||
       ![
         'shorten',
         'expand',
         'fix',
+        'custom',
         'professional',
         'empathetic',
         'casual',
@@ -37,7 +38,7 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Invalid request' }, { status: 400 });
     }
 
-    const rewritten = await rewriteContent(text, action);
+    const rewritten = await rewriteContent(text, action, prompt);
     return NextResponse.json({ text: rewritten });
   } catch (error) {
     console.error('Rewrite error:', error);

--- a/src/lib/ai/rewriteContent.ts
+++ b/src/lib/ai/rewriteContent.ts
@@ -8,11 +8,13 @@ export async function rewriteContent(
     | "shorten"
     | "expand"
     | "fix"
+    | "custom"
     | "professional"
     | "empathetic"
     | "casual"
     | "neutral"
     | "educational",
+  customPrompt?: string
 ) {
   let prompt: string;
   switch (action) {
@@ -40,13 +42,17 @@ export async function rewriteContent(
     case "educational":
       prompt = `Rewrite the following text in an educational tone:\n\n${text}`;
       break;
+    case "custom":
+      if (!customPrompt) throw new Error("Custom prompt required");
+      prompt = `${customPrompt}\n\n${text}`;
+      break;
     default:
       throw new Error("Unsupported action");
   }
 
   const response = await openai.responses.create({
     model: "gpt-4.1-mini",
-    instructions: "You rewrite content based on a provided action.",
+    instructions: "You rewrite content based on a provided action or prompt.",
     input: prompt,
   });
 


### PR DESCRIPTION
## Summary
- allow custom prompt rewriting
- extend rewrite menu UI and positioning
- enlarge rewrite dropdown, open above button
- update API & server logic for custom prompt
- widen rewrite menu width

## Testing
- `npx -y next@15.3.4 lint`


------
https://chatgpt.com/codex/tasks/task_e_685711686ab08327bc237650ac4bd6c8