### PR TITLE
Refactor idea details page

### DIFF
--- a/src/services/content.ts
+++ b/src/services/content.ts
@@ -1,0 +1,54 @@
+import { fetchApi } from './api'
+
+export type RewriteAction =
+  | 'shorten'
+  | 'expand'
+  | 'fix'
+  | 'custom'
+  | 'professional'
+  | 'empathetic'
+  | 'casual'
+  | 'neutral'
+  | 'educational'
+
+export interface GenerateContentParams {
+  ideaText: string
+  projectId: string
+  platform: string
+  regenerate?: boolean
+  accessToken: string
+}
+
+export interface RewriteContentParams {
+  text: string
+  action: RewriteAction
+  prompt?: string
+  accessToken: string
+}
+
+export async function generateContent({
+  ideaText,
+  projectId,
+  platform,
+  regenerate = false,
+  accessToken,
+}: GenerateContentParams) {
+  return fetchApi<{ content: string }>('/api/content/generate', {
+    method: 'POST',
+    body: { idea_text: ideaText, project_id: projectId, platform, regenerate },
+    accessToken,
+  })
+}
+
+export async function rewriteContent({
+  text,
+  action,
+  prompt,
+  accessToken,
+}: RewriteContentParams) {
+  return fetchApi<{ text: string }>('/api/content/rewrite', {
+    method: 'POST',
+    body: { text, action, prompt },
+    accessToken,
+  })
+}

--- a/src/services/ideas.ts
+++ b/src/services/ideas.ts
@@ -17,6 +17,13 @@ export interface GenerateIdeasParams {
   accessToken: string
 }
 
+export interface UpdateIdeaParams {
+  ideaId: string
+  ideaText?: string
+  status?: Idea['status']
+  accessToken: string
+}
+
 export class IdeasService {
   static async getForProject(projectId: string, userId: string): Promise<Idea[]> {
     const supabase = getSupabaseClient()
@@ -58,4 +65,12 @@ export class IdeasService {
     })
     return data.ideas
   }
-} 
+
+  static async update({ ideaId, ideaText, status, accessToken }: UpdateIdeaParams): Promise<void> {
+    await fetchApi("/api/ideas/update", {
+      method: "POST",
+      body: { idea_id: ideaId, idea_text: ideaText, status },
+      accessToken,
+    })
+  }
+}


### PR DESCRIPTION
## Summary
- abstract API calls for generating and rewriting content
- add idea update capability to service layer
- simplify idea details page logic using new helpers

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6857b66dd1148327847834e41ba62258