### PR TITLE
Add hero section to landing page

### DIFF
--- a/public/hero-screenshot.svg
+++ b/public/hero-screenshot.svg
@@ -1,0 +1,13 @@
+<svg width="640" height="400" viewBox="0 0 640 400" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="640" height="400" rx="8" fill="white" stroke="#E5E7EB"/>
+  <rect x="20" y="20" width="600" height="40" rx="4" fill="#F3F4F6"/>
+  <rect x="20" y="70" width="600" height="40" rx="4" fill="#F3F4F6"/>
+  <rect x="20" y="120" width="600" height="40" rx="4" fill="#F3F4F6"/>
+  <rect x="20" y="200" width="600" height="160" rx="4" fill="#F9FAFB"/>
+  <rect x="40" y="220" width="110" height="30" rx="15" fill="#ECFDF5" stroke="#10B981"/>
+  <rect x="170" y="220" width="110" height="30" rx="15" fill="#EFF6FF" stroke="#3B82F6"/>
+  <rect x="300" y="220" width="110" height="30" rx="15" fill="#FEF2F2" stroke="#EF4444"/>
+  <text x="55" y="240" font-family="Arial, Helvetica, sans-serif" font-size="12" fill="#065F46">Regenerate</text>
+  <text x="185" y="240" font-family="Arial, Helvetica, sans-serif" font-size="12" fill="#1E40AF">Rewrite</text>
+  <text x="325" y="240" font-family="Arial, Helvetica, sans-serif" font-size="12" fill="#991B1B">Schedule</text>
+</svg>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import { useRouter } from "next/navigation"
 import Link from "next/link"
+import Image from "next/image"
 import { useAuth } from "@/contexts/AuthContext"
 
 export default function HomePage() {
@@ -10,34 +10,64 @@ export default function HomePage() {
   return (
     <div>
       <nav className="navbar rounded-box shadow-base-300/20 shadow-sm">
-            <div className="w-full md:flex md:items-center md:gap-2">
-                <div className="flex items-center justify-between">
-                <div className="navbar-start items-center justify-between max-md:w-full">
-                    <Link 
-                      href="/dashboard" 
-                      className="link text-base-content link-neutral text-xl font-bold no-underline"
-                    >
-                      Posty
-                    </Link>
-                    <div className="md:hidden">
-                    <button type="button" className="collapse-toggle btn btn-outline btn-secondary btn-sm btn-square" data-collapse="#default-navbar-collapse" aria-controls="default-navbar-collapse" aria-label="Toggle navigation" >
-                        <span className="icon-[tabler--menu-2] collapse-open:hidden size-4"></span>
-                        <span className="icon-[tabler--x] collapse-open:block hidden size-4"></span>
-                    </button>
-                    </div>
-                </div>
-                </div>
-                <div id="default-navbar-collapse" className="md:navbar-end collapse hidden grow basis-full overflow-hidden transition-[height] duration-300 max-md:w-full" >
-                <ul className="menu md:menu-horizontal gap-2 p-0 text-base max-md:mt-2">
-                    {user && session ? (
-                      <li><Link href="/dashboard">Dashboard</Link></li>
-                    ) : (
-                      <li><Link href="/login">Login</Link></li>
-                    )}
-                </ul>
+        <div className="w-full md:flex md:items-center md:gap-2">
+          <div className="flex items-center justify-between">
+            <div className="navbar-start items-center justify-between max-md:w-full">
+              <Link
+                href="/dashboard"
+                className="link text-base-content link-neutral text-xl font-bold no-underline"
+              >
+                Posty
+              </Link>
+              <div className="md:hidden">
+                <button type="button" className="collapse-toggle btn btn-outline btn-secondary btn-sm btn-square" data-collapse="#default-navbar-collapse" aria-controls="default-navbar-collapse" aria-label="Toggle navigation" >
+                  <span className="icon-[tabler--menu-2] collapse-open:hidden size-4"></span>
+                  <span className="icon-[tabler--x] collapse-open:block hidden size-4"></span>
+                </button>
               </div>
+            </div>
           </div>
-        </nav>
+          <div id="default-navbar-collapse" className="md:navbar-end collapse hidden grow basis-full overflow-hidden transition-[height] duration-300 max-md:w-full" >
+            <ul className="menu md:menu-horizontal gap-2 p-0 text-base max-md:mt-2">
+              {user && session ? (
+                <li><Link href="/dashboard">Dashboard</Link></li>
+              ) : (
+                <li><Link href="/login">Login</Link></li>
+              )}
+            </ul>
+          </div>
+        </div>
+      </nav>
+      <section className="mt-16 flex flex-col items-center justify-center px-4 md:flex-row md:gap-16">
+        <div className="max-w-xl text-center md:text-left">
+          <h1 className="text-4xl font-bold md:text-5xl">
+            Create, refine &amp; schedule content in place.
+          </h1>
+          <p className="mt-4 text-lg text-base-content/70">
+            Posty turns brainstorming into published posts across X, Telegram &amp; LinkedIn—powered by AI and built right inside your browser.
+          </p>
+          <div className="mt-6 flex flex-col items-center gap-4 md:flex-row md:items-start">
+            <Link href="/login" className="btn btn-primary w-full md:w-auto">
+              Login
+            </Link>
+            <a
+              href="https://cal.com"
+              className="btn btn-outline w-full md:w-auto"
+            >
+              Book a 5-min demo
+            </a>
+          </div>
+        </div>
+        <div className="mt-10 w-full md:mt-0 md:w-1/2">
+          <Image
+            src="/hero-screenshot.svg"
+            alt="Posty idea list screenshot"
+            width={640}
+            height={400}
+            className="w-full rounded-lg border shadow-sm"
+          />
+        </div>
+      </section>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- design hero screenshot with highlighted action buttons
- add hero section on the main landing page with headline, subtext and calls to action

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist` from `fonts.googleapis.com`)*

------
https://chatgpt.com/codex/tasks/task_e_6857b9a233b88327b6c768d806f28512