### PR TITLE
Add hero section to landing page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link"
 import { useAuth } from "@/contexts/AuthContext"
+import HeroScreenshot from "@/components/HeroScreenshot"
 
 export default function HomePage() {
   const { user, session } = useAuth()
@@ -37,6 +38,29 @@ export default function HomePage() {
               </div>
           </div>
         </nav>
+        <section className="bg-base-200">
+          <div className="container mx-auto px-4 py-20 flex flex-col items-center text-center gap-10 md:flex-row md:text-left md:gap-16">
+            <div className="max-w-xl space-y-6">
+              <h1 className="text-4xl font-bold leading-tight">
+                Create, refine &amp; schedule content in place.
+              </h1>
+              <p className="text-base-content/70">
+                Posty turns brainstorming into published posts across X, Telegram &amp; LinkedIn—powered by AI and built right inside your browser.
+              </p>
+              <div className="flex flex-col sm:flex-row items-center justify-center md:justify-start gap-3">
+                <Link href="/login" className="btn btn-primary">
+                  Login
+                </Link>
+                <a href="#" className="btn btn-outline">
+                  Book a 5-min demo
+                </a>
+              </div>
+            </div>
+            <div className="w-full max-w-md">
+              <HeroScreenshot />
+            </div>
+          </div>
+        </section>
     </div>
   )
 }

--- a/src/components/HeroScreenshot.tsx
+++ b/src/components/HeroScreenshot.tsx
@@ -1,0 +1,27 @@
+import React from "react"
+
+export default function HeroScreenshot() {
+  return (
+    <div className="bg-base-100 border border-base-200 rounded-xl shadow-md p-6 w-full max-w-md">
+      <ul className="space-y-3">
+        <li className="flex items-center justify-between bg-base-200 rounded-lg p-3">
+          <span className="text-sm">Launch new product campaign</span>
+          <span className="badge badge-sm badge-info">New</span>
+        </li>
+        <li className="flex items-center justify-between bg-base-200 rounded-lg p-3">
+          <span className="text-sm">Share behind-the-scenes video</span>
+          <span className="badge badge-sm badge-primary">Generated</span>
+        </li>
+        <li className="flex items-center justify-between bg-base-200 rounded-lg p-3">
+          <span className="text-sm">Customer testimonial highlight</span>
+          <span className="badge badge-sm badge-success">Ready</span>
+        </li>
+      </ul>
+      <div className="mt-6 flex justify-center gap-2">
+        <button className="btn btn-sm btn-primary">Regenerate</button>
+        <button className="btn btn-sm btn-outline">Rewrite</button>
+        <button className="btn btn-sm btn-secondary">Schedule</button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add a HeroScreenshot example component
- create a hero section on the landing page with login/demo buttons

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6857bd8daffc83278c37f058a987e43a