### PR TITLE
Add vertical steps how-it-works section

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -107,6 +107,27 @@ export default function HomePage() {
           </div>
         </div>
       </section>
+
+      <section className="container mx-auto px-4 py-16">
+        <h2 className="text-3xl font-bold text-base-content text-center mb-10">How it works</h2>
+        <ol className="relative border-l-2 border-base-300 ml-6 space-y-12">
+          <li className="ml-6">
+            <span className="absolute -left-3 flex h-6 w-6 items-center justify-center rounded-full bg-primary text-primary-content font-bold">1</span>
+            <h3 className="text-xl font-semibold text-base-content mb-1">Capture ideas</h3>
+            <p className="text-base-content/70">Manually jot down a thought or generate platform-specific ideas with AI.</p>
+          </li>
+          <li className="ml-6">
+            <span className="absolute -left-3 flex h-6 w-6 items-center justify-center rounded-full bg-primary text-primary-content font-bold">2</span>
+            <h3 className="text-xl font-semibold text-base-content mb-1">Polish with AI</h3>
+            <p className="text-base-content/70">Use smart rewrite actions like “Shorten,” “Add hook,” or “Change tone” to shape your message.</p>
+          </li>
+          <li className="ml-6">
+            <span className="absolute -left-3 flex h-6 w-6 items-center justify-center rounded-full bg-primary text-primary-content font-bold">3</span>
+            <h3 className="text-xl font-semibold text-base-content mb-1">Generate content</h3>
+            <p className="text-base-content/70">Turn ideas into complete drafts tailored for Twitter, LinkedIn, or Instagram — ready to post.</p>
+          </li>
+        </ol>
+      </section>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add new "How it works" section with vertical steps on the home page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857e857f1bc8327a660459d53e1f079