### PR TITLE
Add pricing section

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link"
 import Image from "next/image"
 import { useAuth } from "@/contexts/AuthContext"
+import PricingSection from "@/components/PricingSection"
 
 export default function HomePage() {
   const { user, session } = useAuth()
@@ -128,6 +129,8 @@ export default function HomePage() {
           </li>
         </ol>
       </section>
+
+      <PricingSection />
     </div>
   )
 }

--- a/src/components/PricingSection.tsx
+++ b/src/components/PricingSection.tsx
@@ -1,0 +1,66 @@
+import Link from "next/link"
+
+const plans = [
+  {
+    name: "Starter",
+    price: "8.99$",
+    ideas: 200,
+    drafts: 200,
+    lqImages: 20,
+    hqImages: 5,
+    projects: 1,
+  },
+  {
+    name: "Creator",
+    price: "18.99$",
+    ideas: 400,
+    drafts: 400,
+    lqImages: 50,
+    hqImages: 20,
+    projects: 5,
+  },
+  {
+    name: "Studio",
+    price: "45$",
+    ideas: 1000,
+    drafts: 800,
+    lqImages: 100,
+    hqImages: 100,
+    projects: 20,
+  },
+]
+
+export default function PricingSection() {
+  return (
+    <section className="container mx-auto px-4 py-16">
+      <h2 className="text-3xl font-bold text-base-content text-center mb-10">
+        Pricing
+      </h2>
+      <div className="grid gap-8 md:grid-cols-3">
+        {plans.map((plan) => (
+          <div
+            key={plan.name}
+            className="rounded-xl border border-base-300 p-6 shadow-sm flex flex-col"
+          >
+            <h3 className="text-xl font-semibold text-base-content text-center mb-2">
+              {plan.name}
+            </h3>
+            <div className="text-4xl font-bold text-base-content text-center mb-4">
+              {plan.price}
+            </div>
+            <ul className="space-y-1 text-base-content/70 flex-1">
+              <li>{plan.ideas} idea generations</li>
+              <li>{plan.drafts} drafts generated/refined</li>
+              <li>{plan.lqImages} lq images (coming soon)</li>
+              <li>{plan.hqImages} hq images (coming soon)</li>
+              <li>{plan.projects} project{plan.projects > 1 ? "s" : ""}</li>
+            </ul>
+            <Link href="/login" className="btn btn-primary mt-6 w-full">
+              Get Started
+            </Link>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- add pricing section and pricing cards component
- show the pricing section on the landing page

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist`)*

------
https://chatgpt.com/codex/tasks/task_e_6857ecc4e8108327bdec9899ac3b149e