### PR TITLE
Add CTA banner on landing page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link"
 import Image from "next/image"
 import { useAuth } from "@/contexts/AuthContext"
 import PricingSection from "@/components/PricingSection"
+import CTABanner from "@/components/CTABanner"
 
 export default function HomePage() {
   const { user, session } = useAuth()
@@ -130,7 +131,8 @@ export default function HomePage() {
         </ol>
       </section>
 
-      <PricingSection />
-    </div>
+        <PricingSection />
+        <CTABanner />
+      </div>
   )
 }

--- a/src/components/CTABanner.tsx
+++ b/src/components/CTABanner.tsx
@@ -1,0 +1,23 @@
+"use client"
+
+import Link from "next/link"
+import { useAuth } from "@/contexts/AuthContext"
+
+export default function CTABanner() {
+  const { user, session } = useAuth()
+  const href = user && session ? "/dashboard" : "/login"
+
+  return (
+    <section className="container mx-auto px-4 py-16 text-center">
+      <h2 className="text-3xl font-bold text-base-content mb-4">
+        Ready to publish smarter?
+      </h2>
+      <p className="text-base-content/70 mb-6">
+        Sign in and turn your first idea into content in seconds.
+      </p>
+      <Link href={href} className="btn btn-primary">
+        Start Creating
+      </Link>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- add a `CTABanner` component
- display the banner at the bottom of the landing page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6857ef2feddc832788f579fae7ca3c4e