### PR TITLE
Add footer to landing page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import Image from "next/image"
 import { useAuth } from "@/contexts/AuthContext"
 import PricingSection from "@/components/PricingSection"
 import CTABanner from "@/components/CTABanner"
+import Footer from "@/components/Footer"
 
 export default function HomePage() {
   const { user, session } = useAuth()
@@ -133,6 +134,7 @@ export default function HomePage() {
 
         <PricingSection />
         <CTABanner />
+        <Footer />
       </div>
   )
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link"
+
+export default function Footer() {
+  return (
+    <footer className="container mx-auto px-4 py-16 text-center space-y-2 border-t border-base-300">
+      <div>
+        Company: {" "}
+        <Link href="https://twitter.com" className="link link-neutral" target="_blank" rel="noopener noreferrer">
+          Twitter
+        </Link>{" "}
+        &middot; {" "}
+        <Link href="https://t.me" className="link link-neutral" target="_blank" rel="noopener noreferrer">
+          Telegram
+        </Link>
+      </div>
+      <div>
+        Legal: {" "}
+        <Link href="#" className="link link-neutral">
+          Privacy
+        </Link>{" "}
+        &middot; {" "}
+        <Link href="#" className="link link-neutral">
+          Terms
+        </Link>
+      </div>
+      <div>© 2025 Posty, built in Ukraine</div>
+    </footer>
+  )
+}


### PR DESCRIPTION
## Summary
- add footer component with links for Company, Legal, and copyright notice
- include new footer at the bottom of the home page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6857f54ee140832791e0a3c0e04028f5