### PR TITLE
Add idea images with Supabase storage

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,20 @@
 import type { NextConfig } from "next";
 
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const hostname = supabaseUrl ? new URL(supabaseUrl).host : undefined;
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: hostname
+      ? [
+          {
+            protocol: "https",
+            hostname,
+            pathname: "/storage/v1/object/public/**",
+          },
+        ]
+      : [],
+  },
 };
 
 export default nextConfig;

--- a/supabase/migrations/20250701000000_create_idea_images_bucket.sql
+++ b/supabase/migrations/20250701000000_create_idea_images_bucket.sql
@@ -1,0 +1,3 @@
+-- create public bucket for idea images
+insert into storage.buckets (id, name, public)
+values ('idea-images', 'idea-images', true);


### PR DESCRIPTION
## Summary
- allow remote Supabase images in Next config
- add migration for a public `idea-images` storage bucket
- enable upload of images on the idea detail page
- display uploaded image below generated content

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68613ea683cc83278bc75697908ec4fc