### PR TITLE
Add image upload for ideas

### DIFF
--- a/src/app/api/ideas/update/route.ts
+++ b/src/app/api/ideas/update/route.ts
@@ -31,15 +31,16 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const { idea_id, idea_text, status } = await request.json();
+    const { idea_id, idea_text, status, image_url } = await request.json();
 
-    if (!idea_id || (!idea_text && !status)) {
+    if (!idea_id || (!idea_text && !status && !image_url)) {
       return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
     }
 
     const updates: Record<string, unknown> = {};
     if (idea_text) updates.idea_text = idea_text;
     if (status) updates.status = status;
+    if (image_url) updates.image_url = image_url;
 
     const { error } = await supabase
       .from('ideas')

--- a/src/services/ideas.ts
+++ b/src/services/ideas.ts
@@ -21,6 +21,7 @@ export interface UpdateIdeaParams {
   ideaId: string
   ideaText?: string
   status?: Idea['status']
+  imageUrl?: string
   accessToken: string
 }
 
@@ -66,10 +67,10 @@ export class IdeasService {
     return data.ideas
   }
 
-  static async update({ ideaId, ideaText, status, accessToken }: UpdateIdeaParams): Promise<void> {
+  static async update({ ideaId, ideaText, status, imageUrl, accessToken }: UpdateIdeaParams): Promise<void> {
     await fetchApi("/api/ideas/update", {
       method: "POST",
-      body: { idea_id: ideaId, idea_text: ideaText, status },
+      body: { idea_id: ideaId, idea_text: ideaText, status, image_url: imageUrl },
       accessToken,
     })
   }


### PR DESCRIPTION
## Summary
- allow uploading idea images to `idea-images` bucket
- store uploaded URL in `image_url` via updated API route
- display the image and upload input on idea detail page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686145e6f55883278d5f170d59abe971