### PR TITLE
Add AI image generation for ideas

### DIFF
--- a/src/app/(dashboard)/project/[id]/idea/[idea_id]/page.tsx
+++ b/src/app/(dashboard)/project/[id]/idea/[idea_id]/page.tsx
@@ -40,6 +40,7 @@ export default function IdeaContentPage() {
     null,
   );
   const [uploading, setUploading] = useState(false);
+  const [isGeneratingImage, setIsGeneratingImage] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -291,6 +292,29 @@ export default function IdeaContentPage() {
     } finally {
       setUploading(false);
       if (fileInputRef.current) fileInputRef.current.value = '';
+    }
+  };
+
+  const handleGenerateImage = async () => {
+    if (!idea) return;
+    setIsGeneratingImage(true);
+    try {
+      const accessToken = await getAccessToken();
+      if (!accessToken) {
+        toast.error('You must be signed in to generate images.');
+        return;
+      }
+      const { image_url } = await IdeasService.generateImage({
+        ideaId: idea.id,
+        accessToken,
+      });
+      setIdea({ ...idea, image_url });
+      toast.success('✅ Image generated!');
+    } catch (error) {
+      console.error('Error generating image:', error);
+      toast.error('Failed to generate image.');
+    } finally {
+      setIsGeneratingImage(false);
     }
   };
 
@@ -548,6 +572,13 @@ export default function IdeaContentPage() {
               disabled={uploading}
             >
               {uploading ? 'Uploading...' : idea.image_url ? 'Change Image' : 'Upload Image'}
+            </button>
+            <button
+              className="btn btn-primary w-full"
+              onClick={handleGenerateImage}
+              disabled={isGeneratingImage}
+            >
+              {isGeneratingImage ? 'Generating...' : idea.image_url ? 'Regenerate Image' : 'Generate Image'}
             </button>
           </div>
         )}

--- a/src/app/api/ideas/generate-image/route.ts
+++ b/src/app/api/ideas/generate-image/route.ts
@@ -1,0 +1,87 @@
+import { NextResponse } from 'next/server';
+import { createSupabaseServerClient } from '@/lib/supabaseServerClient';
+import { generateImageFromIdea } from '@/lib/ai/generateImage';
+
+function getAccessToken(request: Request): string | null {
+  const authHeader = request.headers.get('authorization');
+  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
+  return authHeader.replace('Bearer ', '');
+}
+
+export async function POST(request: Request) {
+  try {
+    const accessToken = getAccessToken(request);
+    if (!accessToken) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    const supabase = createSupabaseServerClient(accessToken);
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser();
+    if (userError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { idea_id } = await request.json();
+    if (!idea_id) {
+      return NextResponse.json({ error: 'Missing idea_id' }, { status: 400 });
+    }
+
+    const { data: idea, error: ideaError } = await supabase
+      .from('ideas')
+      .select('id, idea_text, project_id')
+      .eq('id', idea_id)
+      .eq('user_id', user.id)
+      .single();
+    if (ideaError || !idea) {
+      return NextResponse.json({ error: 'Idea not found' }, { status: 404 });
+    }
+
+    const { data: project, error: projectError } = await supabase
+      .from('projects')
+      .select('*')
+      .eq('id', idea.project_id)
+      .eq('user_id', user.id)
+      .single();
+    if (projectError || !project) {
+      return NextResponse.json({ error: 'Project not found' }, { status: 404 });
+    }
+
+    const imageBuffer = await generateImageFromIdea(idea.idea_text, project);
+
+    const filePath = `${idea_id}/${Date.now()}.png`;
+    const { error: uploadError } = await supabase.storage
+      .from('idea-images')
+      .upload(filePath, imageBuffer, { contentType: 'image/png' });
+    if (uploadError) {
+      console.error('Upload error:', uploadError);
+      return NextResponse.json(
+        { error: 'Failed to upload image' },
+        { status: 500 },
+      );
+    }
+
+    const { data: publicData } = supabase.storage
+      .from('idea-images')
+      .getPublicUrl(filePath);
+    const image_url = publicData.publicUrl;
+
+    const { error: updateError } = await supabase
+      .from('ideas')
+      .update({ image_url })
+      .eq('id', idea_id)
+      .eq('user_id', user.id);
+    if (updateError) {
+      return NextResponse.json(
+        { error: 'Failed to save image' },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({ image_url });
+  } catch (error) {
+    console.error('Image generation error:', error);
+    return NextResponse.json({ error: 'Failed to generate image' }, { status: 500 });
+  }
+}

--- a/src/lib/ai/generateImage.ts
+++ b/src/lib/ai/generateImage.ts
@@ -1,0 +1,26 @@
+import OpenAI from 'openai';
+import { Project } from '@/types/Project';
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+export async function generateImageFromIdea(
+  idea: string,
+  project: Project,
+): Promise<Buffer> {
+  const prompt = `Create an illustrative image for the following content idea.\n\nProject name: ${project.name}\nNiche: ${project.niche}\nDescription: ${project.description}\nTone: ${project.tone}\nPlatform: ${project.platform}\n\nIdea: ${idea}`;
+
+  const response = await openai.images.generate({
+    model: 'gpt-image-1',
+    prompt,
+    n: 1,
+    size: '1024x1024',
+    response_format: 'b64_json',
+  });
+
+  const b64 = response.data?.[0]?.b64_json;
+  if (!b64) {
+    throw new Error('Failed to generate image');
+  }
+
+  return Buffer.from(b64, 'base64');
+}

--- a/src/services/ideas.ts
+++ b/src/services/ideas.ts
@@ -25,6 +25,11 @@ export interface UpdateIdeaParams {
   accessToken: string
 }
 
+export interface GenerateIdeaImageParams {
+  ideaId: string
+  accessToken: string
+}
+
 export class IdeasService {
   static async getForProject(projectId: string, userId: string): Promise<Idea[]> {
     const supabase = getSupabaseClient()
@@ -71,6 +76,14 @@ export class IdeasService {
     await fetchApi("/api/ideas/update", {
       method: "POST",
       body: { idea_id: ideaId, idea_text: ideaText, status, image_url: imageUrl },
+      accessToken,
+    })
+  }
+
+  static async generateImage({ ideaId, accessToken }: GenerateIdeaImageParams): Promise<{ image_url: string }> {
+    return fetchApi<{ image_url: string }>("/api/ideas/generate-image", {
+      method: "POST",
+      body: { idea_id: ideaId },
       accessToken,
     })
   }


### PR DESCRIPTION
## Summary
- implement server-side image generation using OpenAI `gpt-image-1`
- expose `/api/ideas/generate-image` route
- add client service method to call the route
- update idea detail page with button to generate an image

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686168adfb7883279e99300e8ee3c69d