### PR TITLE
Add GPT-based image generation for ideas

### DIFF
--- a/src/app/(dashboard)/project/[id]/idea/[idea_id]/page.tsx
+++ b/src/app/(dashboard)/project/[id]/idea/[idea_id]/page.tsx
@@ -40,6 +40,7 @@ export default function IdeaContentPage() {
     null,
   );
   const [uploading, setUploading] = useState(false);
+  const [imageGenerating, setImageGenerating] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -294,6 +295,26 @@ export default function IdeaContentPage() {
     }
   };
 
+  const handleGenerateImage = async () => {
+    if (!idea) return;
+    setImageGenerating(true);
+    try {
+      const accessToken = await getAccessToken();
+      if (!accessToken) {
+        toast.error('You must be signed in to generate images.');
+        return;
+      }
+      const imageUrl = await IdeasService.generateImage({ ideaId: idea.id, accessToken });
+      setIdea({ ...idea, image_url: imageUrl });
+      toast.success('✅ Image generated!');
+    } catch (error) {
+      console.error('Error generating image:', error);
+      toast.error('Failed to generate image.');
+    } finally {
+      setImageGenerating(false);
+    }
+  };
+
   if (isLoading) {
     return (
       <div className="container mx-auto max-w-3xl py-20 flex items-center justify-center">
@@ -542,13 +563,22 @@ export default function IdeaContentPage() {
               className="hidden"
               onChange={handleImageUpload}
             />
-            <button
-              className="btn btn-secondary w-full"
-              onClick={() => fileInputRef.current?.click()}
-              disabled={uploading}
-            >
-              {uploading ? 'Uploading...' : idea.image_url ? 'Change Image' : 'Upload Image'}
-            </button>
+            <div className="flex gap-2">
+              <button
+                className="btn btn-secondary flex-1"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={uploading}
+              >
+                {uploading ? 'Uploading...' : idea.image_url ? 'Change Image' : 'Upload Image'}
+              </button>
+              <button
+                className="btn btn-primary flex-1"
+                onClick={handleGenerateImage}
+                disabled={imageGenerating}
+              >
+                {imageGenerating ? 'Generating...' : idea.image_url ? 'Regenerate Image' : 'Generate Image'}
+              </button>
+            </div>
           </div>
         )}
         </div>

--- a/src/app/api/image/generate/route.ts
+++ b/src/app/api/image/generate/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from 'next/server';
+import { createSupabaseServerClient } from '@/lib/supabaseServerClient';
+import { generateIdeaImage } from '@/lib/ai/generateImage';
+
+function getAccessToken(request: Request): string | null {
+  const authHeader = request.headers.get('authorization');
+  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
+  return authHeader.replace('Bearer ', '');
+}
+
+export async function POST(request: Request) {
+  try {
+    const accessToken = getAccessToken(request);
+    if (!accessToken) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    const supabase = createSupabaseServerClient(accessToken);
+    const { data: { user }, error: userError } = await supabase.auth.getUser();
+    if (userError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { idea_id } = await request.json();
+    if (!idea_id) {
+      return NextResponse.json({ error: 'Missing idea_id' }, { status: 400 });
+    }
+
+    const { data: idea, error: ideaError } = await supabase
+      .from('ideas')
+      .select('idea_text, project_id')
+      .eq('id', idea_id)
+      .eq('user_id', user.id)
+      .single();
+    if (ideaError || !idea) {
+      return NextResponse.json({ error: 'Idea not found' }, { status: 404 });
+    }
+
+    const { data: project, error: projectError } = await supabase
+      .from('projects')
+      .select('*')
+      .eq('id', idea.project_id)
+      .eq('user_id', user.id)
+      .single();
+    if (projectError || !project) {
+      return NextResponse.json({ error: 'Project not found' }, { status: 404 });
+    }
+
+    const imageUrl = await generateIdeaImage({ project, ideaText: idea.idea_text });
+    if (!imageUrl) {
+      return NextResponse.json({ error: 'Failed to generate image' }, { status: 500 });
+    }
+
+    const { error: updateError } = await supabase
+      .from('ideas')
+      .update({ image_url: imageUrl })
+      .eq('id', idea_id)
+      .eq('user_id', user.id);
+    if (updateError) {
+      return NextResponse.json({ error: 'Failed to save image' }, { status: 500 });
+    }
+
+    return NextResponse.json({ image_url: imageUrl });
+  } catch (error) {
+    console.error('Image generation error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/lib/ai/generateImage.ts
+++ b/src/lib/ai/generateImage.ts
@@ -1,0 +1,28 @@
+import OpenAI from 'openai';
+import { Project } from '@/types/Project';
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+interface Params {
+  project: Project;
+  ideaText: string;
+}
+
+export async function generateIdeaImage({ project, ideaText }: Params) {
+  const prompt = `Project name: ${project.name}
+Niche: ${project.niche}
+Description: ${project.description}
+Tone: ${project.tone}
+Platform: ${project.platform}
+
+Idea: ${ideaText}
+
+Create an illustrative image representing this idea for the described project.`;
+
+  const response = await openai.images.generate({
+    model: 'gpt-image-1',
+    prompt,
+  });
+
+  return response.data[0]?.url as string | undefined;
+}

--- a/src/services/ideas.ts
+++ b/src/services/ideas.ts
@@ -74,4 +74,13 @@ export class IdeasService {
       accessToken,
     })
   }
+
+  static async generateImage({ ideaId, accessToken }: { ideaId: string; accessToken: string }): Promise<string> {
+    const data = await fetchApi<{ image_url: string }>("/api/image/generate", {
+      method: "POST",
+      body: { idea_id: ideaId },
+      accessToken,
+    })
+    return data.image_url
+  }
 }


### PR DESCRIPTION
## Summary
- enable server-side API route to generate and store an idea image via OpenAI
- add helper in AI library for gpt-image-1
- expose `generateImage` in `IdeasService`
- update idea detail page with 'Generate Image' option

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686168adfb7883279e99300e8ee3c69d