### PR TITLE
Add AI-based image generation

### DIFF
--- a/src/app/(dashboard)/project/[id]/idea/[idea_id]/page.tsx
+++ b/src/app/(dashboard)/project/[id]/idea/[idea_id]/page.tsx
@@ -40,6 +40,7 @@ export default function IdeaContentPage() {
     null,
   );
   const [uploading, setUploading] = useState(false);
+  const [generatingImage, setGeneratingImage] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -291,6 +292,32 @@ export default function IdeaContentPage() {
     } finally {
       setUploading(false);
       if (fileInputRef.current) fileInputRef.current.value = '';
+    }
+  };
+
+  const handleGenerateImage = async () => {
+    if (!idea) return;
+    setGeneratingImage(true);
+    try {
+      const accessToken = await getAccessToken();
+      if (!accessToken) {
+        toast.error('You must be signed in to generate images.');
+        return;
+      }
+      const { imageUrl } = await IdeasService.generateImage({
+        ideaId: idea.id,
+        ideaText: idea.idea_text,
+        content: generatedContent,
+        projectId: params?.id as string,
+        accessToken,
+      });
+      setIdea({ ...idea, image_url: imageUrl });
+      toast.success('✅ Image generated!');
+    } catch (error) {
+      console.error('Error generating image:', error);
+      toast.error('Failed to generate image.');
+    } finally {
+      setGeneratingImage(false);
     }
   };
 
@@ -548,6 +575,13 @@ export default function IdeaContentPage() {
               disabled={uploading}
             >
               {uploading ? 'Uploading...' : idea.image_url ? 'Change Image' : 'Upload Image'}
+            </button>
+            <button
+              className="btn btn-primary w-full"
+              onClick={handleGenerateImage}
+              disabled={generatingImage}
+            >
+              {generatingImage ? 'Generating...' : idea.image_url ? 'Regenerate Image' : 'Generate Image'}
             </button>
           </div>
         )}

--- a/src/app/api/images/generate/route.ts
+++ b/src/app/api/images/generate/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from 'next/server';
+import { createSupabaseServerClient } from '@/lib/supabaseServerClient';
+import { generateImageFromIdea } from '@/lib/ai/generateImage';
+
+function getAccessToken(request: Request): string | null {
+  const authHeader = request.headers.get('authorization');
+  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
+  return authHeader.replace('Bearer ', '');
+}
+
+export async function POST(request: Request) {
+  try {
+    const accessToken = getAccessToken(request);
+    if (!accessToken) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    const supabase = createSupabaseServerClient(accessToken);
+    const { data: { user }, error: userError } = await supabase.auth.getUser();
+    if (userError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { idea_id, idea_text, content, project_id } = await request.json();
+    if (!idea_id || !idea_text || !project_id) {
+      return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
+    }
+
+    const { data: project, error: projectError } = await supabase
+      .from('projects')
+      .select('*')
+      .eq('id', project_id)
+      .eq('user_id', user.id)
+      .single();
+    if (projectError || !project) {
+      return NextResponse.json({ error: 'Project not found' }, { status: 404 });
+    }
+
+    const base64 = await generateImageFromIdea(idea_text, content || '', project);
+
+    const buffer = Buffer.from(base64, 'base64');
+    const filePath = `${idea_id}/${Date.now()}.png`;
+    const { error: uploadError } = await supabase.storage
+      .from('idea-images')
+      .upload(filePath, buffer, { contentType: 'image/png' });
+    if (uploadError) throw uploadError;
+    const { data } = supabase.storage.from('idea-images').getPublicUrl(filePath);
+    const imageUrl = data.publicUrl;
+
+    const { error: updateError } = await supabase
+      .from('ideas')
+      .update({ image_url: imageUrl })
+      .eq('id', idea_id)
+      .eq('user_id', user.id);
+    if (updateError) throw updateError;
+
+    return NextResponse.json({ imageUrl });
+  } catch (error) {
+    console.error('Image generation error:', error);
+    return NextResponse.json({ error: 'Failed to generate image' }, { status: 500 });
+  }
+}

--- a/src/lib/ai/generateImage.ts
+++ b/src/lib/ai/generateImage.ts
@@ -1,0 +1,22 @@
+import OpenAI from 'openai';
+import { Project } from '@/types/Project';
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+export async function generateImageFromIdea(
+  idea: string,
+  content: string,
+  project: Project,
+) {
+  const prompt = `Create an image for the following social media post.\n\nProject Information:\n- Name: ${project.name}\n- Niche: ${project.niche}\n- Description: ${project.description}\n- Tone: ${project.tone}\n- Platform: ${project.platform}\n\nIdea: ${idea}\nContent: ${content}`;
+
+  const response = await openai.images.generate({
+    model: 'gpt-image-1',
+    prompt,
+    n: 1,
+    size: '1024x1024',
+    response_format: 'b64_json',
+  });
+
+  return response.data[0].b64_json as string;
+}

--- a/src/services/ideas.ts
+++ b/src/services/ideas.ts
@@ -25,6 +25,14 @@ export interface UpdateIdeaParams {
   accessToken: string
 }
 
+export interface GenerateImageParams {
+  ideaId: string
+  ideaText: string
+  content: string
+  projectId: string
+  accessToken: string
+}
+
 export class IdeasService {
   static async getForProject(projectId: string, userId: string): Promise<Idea[]> {
     const supabase = getSupabaseClient()
@@ -71,6 +79,14 @@ export class IdeasService {
     await fetchApi("/api/ideas/update", {
       method: "POST",
       body: { idea_id: ideaId, idea_text: ideaText, status, image_url: imageUrl },
+      accessToken,
+    })
+  }
+
+  static async generateImage({ ideaId, ideaText, content, projectId, accessToken }: GenerateImageParams): Promise<{ imageUrl: string }> {
+    return fetchApi<{ imageUrl: string }>("/api/images/generate", {
+      method: "POST",
+      body: { idea_id: ideaId, idea_text: ideaText, content, project_id: projectId },
       accessToken,
     })
   }


### PR DESCRIPTION
## Summary
- add helper to generate images using `gpt-image-1`
- expose `/api/images/generate` route for server-side generation
- call the new endpoint from `IdeasService`
- allow generating images in idea detail page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686168adfb7883279e99300e8ee3c69d